### PR TITLE
Enable CI caching for failed jobs

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -58,6 +58,7 @@ jobs:
           version: ${{ matrix.julia-version }}
 
       - uses: julia-actions/cache@v2
+        id: julia-cache
 
       - name: "Install OSCAR dev version"
         if: ${{ matrix.oscar-version == 'devel' }}
@@ -89,3 +90,12 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Save Julia depot cache on cancel or failure
+        id: julia-cache-save
+        if: (cancelled() || failure()) && runner.environment != 'self-hosted'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ steps.julia-cache.outputs.cache-paths }}
+          key: ${{ steps.julia-cache.outputs.cache-key }}


### PR DESCRIPTION
Code blocks are taken from [julia-actions/cache#caching-even-if-an-intermediate-job-fails](https://github.com/julia-actions/cache?rgh-link-date=2025-04-16T14%3A49%3A26Z#caching-even-if-an-intermediate-job-fails).

The main motivation behind this is that a CI job that fails during the tests discards its cache. But some of the things in the depot would still be worthwile to cache, e.g. downloaded artifacts, precompilation results (in particular of deps).