### PR TITLE
Add upstreamed `JSONSerializer(serialize_refs=false)`

### DIFF
--- a/ext/TestExt/TestExt.jl
+++ b/ext/TestExt/TestExt.jl
@@ -15,6 +15,15 @@ function PBWDeformations.test_save_load_roundtrip(func, path, original::T;
     @test loaded isa T
     func(loaded)
 
+    # save and load from a file without saving references
+    filename = joinpath(path, "original.json")
+    save(filename, original; serializer=PBWDeformations.JSONSerializerNoRefs(), kw...)
+    @test !any(line -> contains(line, "_refs"), eachline(filename))
+    loaded = load(filename; params=params, serializer=PBWDeformations.JSONSerializerNoRefs(), kw...)
+
+    @test loaded isa T
+    func(loaded)
+
     # save and load from an IO buffer
     io = IOBuffer()
     save(io, original; kw...)

--- a/src/OscarPatches.jl
+++ b/src/OscarPatches.jl
@@ -71,3 +71,20 @@ function Oscar.load_object(s::DeserializerState, ::Type{MatSpace}, base_ring::Sm
   nrows = Oscar.load_object(s, Int, :nrows)
   return matrix_space(base_ring, nrows, ncols)
 end
+
+# upstreamed in https://github.com/oscar-system/Oscar.jl/pull/5094
+@static if !isdefined(Oscar, :Serialization)
+    struct JSONSerializerNoRefs <: Oscar.OscarSerializer end
+
+    function Oscar.handle_refs(s::Oscar.SerializerState{JSONSerializerNoRefs}) end
+
+elseif !isdefined(Oscar.Serialization, :should_handle_refs)
+    struct JSONSerializerNoRefs <: Oscar.Serialization.OscarSerializer end
+
+    function Oscar.Serialization.handle_refs(s::Oscar.Serialization.SerializerState{JSONSerializerNoRefs}) end
+
+else
+    function JSONSerializerNoRefs()
+        return Oscar.Serialization.JSONSerializer(serialize_refs=false)
+    end
+end


### PR DESCRIPTION
Has been added to OSCAR in https://github.com/oscar-system/Oscar.jl/pull/5094, but I don't wanna wait for a release